### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/xpertforextradeinc/CediPay/security/code-scanning/1](https://github.com/xpertforextradeinc/CediPay/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block that grants only the minimal privileges required. For this CI job, the only clear need is read access to the repository contents so `actions/checkout` can fetch the code. No steps push commits, modify issues, or interact with other GitHub resources, so `contents: read` at the workflow or job level is sufficient.

The best fix without changing existing functionality is to add a root-level `permissions:` block right after the `name:` line in `.github/workflows/ci.yml`. This applies to all jobs in the workflow (currently only `test`) and ensures the `GITHUB_TOKEN` is restricted to `contents: read`. Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between line 1 (`name: CI`) and line 3 (`on:`).  
No additional imports, methods, or definitions are needed since this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
