### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/src/routes/webhook.ts
+++ b/src/routes/webhook.ts
@@ -8,11 +8,18 @@ import {
   getWebhookDelivery,
 } from '../controllers/webhookController';
 import { authenticateToken } from '../middleware/auth';
+import rateLimit from 'express-rate-limit';
 
 const router = Router();
 
+const webhookRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs for webhook routes
+});
+
 // All webhook routes require authentication
 router.use(authenticateToken);
+router.use(webhookRateLimiter);
 
 // Webhook endpoint management
 router.post('/endpoints', registerWebhook);


### PR DESCRIPTION
Potential fix for [https://github.com/xpertforextradeinc/CediPay/security/code-scanning/4](https://github.com/xpertforextradeinc/CediPay/security/code-scanning/4)

In general, the fix is to introduce a rate-limiting middleware for these webhook routes so that an individual client (typically per IP or per token) cannot issue unbounded numbers of requests in a short time. The standard approach in Express/TypeScript is to use `express-rate-limit`, configure an appropriate window and maximum request count, and apply it with `router.use(limiter)` or per-route as needed.

For this file, the minimal, non-breaking change is:
- Import `express-rate-limit`.
- Define a limiter instance configured for webhook operations (for example, a moderate cap like 100 requests per 15 minutes per IP).
- Apply the limiter to all routes in this router, immediately after `authenticateToken`, so that only authenticated clients are rate-limited on these webhook management/history endpoints.

Concretely, in `src/routes/webhook.ts`:
- Add `import rateLimit from 'express-rate-limit';` (ES default import) right after the existing imports.
- Add a `const webhookRateLimiter = rateLimit({ ... })` definition after the `Router()` initialization.
- Add `router.use(webhookRateLimiter);` after `router.use(authenticateToken);`.
No existing handlers or signatures need to change; functionality remains the same except for throttling excessive request rates.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
